### PR TITLE
🔧 Fix resolve video layout shift issue

### DIFF
--- a/layouts/PostBanner.tsx
+++ b/layouts/PostBanner.tsx
@@ -32,7 +32,10 @@ export default function PostMinimal({ content, next, prev, children }: LayoutPro
             <div className="w-full">
               <Bleed>
                 <figure>
-                  <div className="relative w-full overflow-hidden rounded-xl bg-black pb-[56.25%]">
+                  <div className="relative w-full overflow-hidden rounded-xl pb-[56.25%]">
+                    <div className="absolute inset-0 flex items-center justify-center bg-gray-200">
+                      <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-transparent"></div>
+                    </div>
                     <video
                       autoPlay
                       muted

--- a/layouts/PostBanner.tsx
+++ b/layouts/PostBanner.tsx
@@ -32,10 +32,35 @@ export default function PostMinimal({ content, next, prev, children }: LayoutPro
             <div className="w-full">
               <Bleed>
                 <figure>
-                  <video autoPlay muted loop playsInline preload="auto">
-                    <source src="/static/videos/banner-1.mp4" type="video/mp4" />
-                    Your browser does not support the video tag.
-                  </video>
+                  <div
+                    style={{
+                      position: 'relative',
+                      width: '100%',
+                      paddingBottom: '56.25%',
+                      backgroundColor: '#000',
+                      borderRadius: '12px',
+                    }}
+                  >
+                    <video
+                      autoPlay
+                      muted
+                      loop
+                      playsInline
+                      preload="auto"
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        height: '100%',
+                        objectFit: 'cover',
+                        borderRadius: '12px',
+                      }}
+                    >
+                      <source src="/static/videos/banner-1.mp4" type="video/mp4" />
+                      Your browser does not support the video tag.
+                    </video>
+                  </div>
                   <figcaption>Sample video from Artlist.io</figcaption>
                 </figure>
               </Bleed>

--- a/layouts/PostBanner.tsx
+++ b/layouts/PostBanner.tsx
@@ -32,30 +32,14 @@ export default function PostMinimal({ content, next, prev, children }: LayoutPro
             <div className="w-full">
               <Bleed>
                 <figure>
-                  <div
-                    style={{
-                      position: 'relative',
-                      width: '100%',
-                      paddingBottom: '56.25%',
-                      backgroundColor: '#000',
-                      borderRadius: '12px',
-                    }}
-                  >
+                  <div className="relative w-full overflow-hidden rounded-xl bg-black pb-[56.25%]">
                     <video
                       autoPlay
                       muted
                       loop
                       playsInline
                       preload="auto"
-                      style={{
-                        position: 'absolute',
-                        top: 0,
-                        left: 0,
-                        width: '100%',
-                        height: '100%',
-                        objectFit: 'cover',
-                        borderRadius: '12px',
-                      }}
+                      className="absolute inset-0 h-full w-full object-cover"
                     >
                       <source src="/static/videos/banner-1.mp4" type="video/mp4" />
                       Your browser does not support the video tag.


### PR DESCRIPTION
***⚠️ Note**: The sample video used for the banner is sourced from Artlist.io and is included for demo purposes.*

##  Description:

This PR addresses the layout shift issue on the home page caused by the banner video. Previously, the video took some time to load, resulting in the elements below it being pushed down after the video was rendered. This caused a jarring experience for users.

To fix this, a placeholder spinner with the same dimensions as the video has been added. The placeholder ensures layout stability by maintaining the space for the video while it loads, preventing the elements below from jumping.

## Demo:

You can view the live website here: [Future with AI](https://futurewithai.xyz)

|Before Change|After Change V1|After Change V2|
|-------------|---------------|---------------|
|![loading-improvement-before](https://github.com/user-attachments/assets/9310f588-7e27-4171-ba2e-53b49a96b4b9)|![loading-improvement-after-1](https://github.com/user-attachments/assets/faf7560c-bea9-4548-aa6b-9446cc4a286b)|![loading-improvement-after-2](https://github.com/user-attachments/assets/92aebb85-ca9b-4ab3-8e53-75bba4cf3d7c)|